### PR TITLE
[refactor] 이미지 디스크 캐싱에 NSCache 이용하게 변경

### DIFF
--- a/SearchBook/book-detail/BookDetailViewController.swift
+++ b/SearchBook/book-detail/BookDetailViewController.swift
@@ -89,7 +89,7 @@ final class BookDetailViewController: UIViewController, APIRequestable {
         if let image = item.image, let url = URL(string: image) {
             let imageView = UIImageView()
             stackView.addArrangedSubview(imageView)
-            ImageAssetManager().request(url) { image in
+            ImageAssetManager.shared.request(url) { image in
                 DispatchQueue.main.async {
                     imageView.image = image
                 }

--- a/SearchBook/book-search/SimpleBookCell.swift
+++ b/SearchBook/book-search/SimpleBookCell.swift
@@ -72,7 +72,7 @@ final class SimpleBookCell: UICollectionViewCell {
     }
     
     func bind(_ item: SimpleBook) {
-        ImageAssetManager().request(item.image.flatMap({ URL(string: $0) })) { [weak self] image in
+        ImageAssetManager.shared.request(item.image.flatMap({ URL(string: $0) })) { [weak self] image in
             DispatchQueue.main.async {
                 self?.imageView.image = image
             }


### PR DESCRIPTION
- NSCache 를 사용하면, 시스템의 메모리 상태에 따라 자동으로 캐싱된 데이터를 지워준다.
- 추가로, thread-safe가 보장되기 때문에 별도 큐로 관리할 필요가 없다.