### PR TITLE
[refactor] 새로운 cell이 로드될 때 이미지가 깜빡거림

### DIFF
--- a/SearchBook/book-search/SimpleBookCell.swift
+++ b/SearchBook/book-search/SimpleBookCell.swift
@@ -71,6 +71,11 @@ final class SimpleBookCell: UICollectionViewCell {
         self.priceLabel = priceLabel
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+    }
+    
     func bind(_ item: SimpleBook) {
         ImageAssetManager.shared.request(item.image.flatMap({ URL(string: $0) })) { [weak self] image in
             DispatchQueue.main.async {


### PR DESCRIPTION
- 완전히 해결되진 않았음.
- data 자체가 변경되었으므로 reloadData를 호출하는 건 유지해야하고 (reloadSection은 이미 로드된 섹션일 경우에만 호출 가능한 듯, 에러난다.)
- prepareForReus에 이미지뷰를 리셋하는 코드를 추가했는데, 덜해졌지만 아직 조금 깜빡인다. 예상하기로는 prepareForReuse 가 호출된 후에 image setting 코드가 asynchronous 하게 호출돼서 그럴 수 있을 것 같다. 

#### NOTES
- imageResourceManager 쪽에서 task.cancel() 이 가능하게 변경해볼 수 있을 것 같다.